### PR TITLE
Correct defines names in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url='http://www.PhyWhisperer.com',
     packages=find_packages('software'),
     package_dir={'': 'software'},
-    package_data={'': ['firmware/defines.v']},
+    package_data={'': ['firmware/defines_usb.v', 'firmware/defines_pw.v']},
     install_requires=[
         'pyserial',
         'crcmod',


### PR DESCRIPTION
Update the defines file names in setup.py since they have been split by 1fd2caba11282a16a90fd7f7e0929607435fd204. If not using Usb class will failed:

```python
import phywhisperer.usb as pw
phy = pw.Usb()

---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-66-8fba2a0fae4f> in <module>
      1 import phywhisperer.usb as pw
----> 2 phy = pw.Usb()

/usr/local/lib/python3.8/dist-packages/phywhisperer-0.1.0-py3.8.egg/phywhisperer/usb.py in __init__(self, viewsb)
     56         self.usb_trigger_freq = 240E6 #internal frequency used for trigger ticks
     57         self.entries_captured = 0
---> 58         self.slurp_defines()
     59         # Set up the PW device to handle packets in ViewSB:
     60         if viewsb:

/usr/local/lib/python3.8/dist-packages/phywhisperer-0.1.0-py3.8.egg/phywhisperer/usb.py in slurp_defines(self)
     72                          pkg_resources.resource_filename('phywhisperer', 'firmware/defines_usb.v')]
     73         for i,defines_file in enumerate(defines_files):
---> 74             defines = open(defines_file, 'r')
     75             define_regex_base  =   re.compile(r'`define')
     76             define_regex_reg   =   re.compile(r'`define\s+?REG_')

FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/dist-packages/phywhisperer-0.1.0-py3.8.egg/phywhisperer/firmware/defines_pw.v'
```