### PR TITLE
Documentation and udev rule fixes

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -83,7 +83,7 @@ And reset the udev system:
 Finally log out & in again for the group change to take effect.
 
 You can always find the latest version of this file on
-`Github <https://raw.githubusercontent.com/newaetech/chipwhisperer/master/hardware/99-newae.rules>`_.
+`Github <https://raw.githubusercontent.com/newaetech/phywhispererusb/master/drivers/99-newae.rules>`_.
 
 
 .. _prerequisites-windows:

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -69,21 +69,28 @@ have to make a file called :code:`/etc/udev/rules.d/99-newae.rules`. The content
 .. code::
 
     # Match all CW devices
-    SUBSYSTEM=="usb", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="ace[0-9]|c[3-6][0-9][0-9]", TAG+="uaccess"
+    SUBSYSTEM=="usb", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="ace[0-9]|c[3-6][0-9][0-9]", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
 Alternatively, you can just copy :code:`phywhispererusb/drivers/99-newae.rules`
-to :code:`/etc/udev/rules.d/`.
+to :code:`/etc/udev/rules.d/`. You can always find the latest version of this
+file on
+`Github <https://raw.githubusercontent.com/newaetech/phywhispererusb/master/drivers/99-newae.rules>`_.
 
-And reset the udev system:
+Tell udev to reload its rules to make the new rules take effect:
 
 .. code:: bash
 
     sudo udevadm control --reload-rules
 
-Finally log out & in again for the group change to take effect.
+On systems that don't use systemd, and on systems that are "headless" (being
+operated remotely over SSH), you will need to add your user to the
+:code:`plugdev` group:
 
-You can always find the latest version of this file on
-`Github <https://raw.githubusercontent.com/newaetech/phywhispererusb/master/drivers/99-newae.rules>`_.
+.. code:: bash
+
+    sudo usermod -a -G plugdev YOUR-USERNAME
+
+Log out and in again for the group change to take effect.
 
 
 .. _prerequisites-windows:

--- a/drivers/99-newae.rules
+++ b/drivers/99-newae.rules
@@ -3,12 +3,12 @@
 # To use this file
 # 1) Unplug all NewAE hardware
 # 2) Copy to /etc/udev/rules.d/
-# 3) Add your username to the plugdev group:
+# 3) Add your username to the plugdev group (on non-systemd or headless systems):
 #    $ sudo usermod -a -G plugdev YOUR-USERNAME
 # 4) Reset the udev system:
 #    $ sudo udevadm control --reload-rules
-# 5) Log in/out again for changes to take effect
+# 5) Log out and in again for the group change to take effect
 # 6) Connect hardware
 #
 # Match all CW devices
-SUBSYSTEM=="usb", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="ace[0-9]|c[3-6][0-9][0-9]", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="ace[0-9]|c[3-6][0-9][0-9]", MODE="660", GROUP="plugdev", TAG+="uaccess"


### PR DESCRIPTION
This fixes a broken link in the documentation, adds support for non-systemd systems and headless device access, and reorganizes and expands on the corresponding documentation to make it clearer and easier to follow.